### PR TITLE
Check pigpiod connection in eyes module

### DIFF
--- a/mini_bdx_runtime/mini_bdx_runtime/eyes.py
+++ b/mini_bdx_runtime/mini_bdx_runtime/eyes.py
@@ -47,7 +47,12 @@ class Eyes:
                  max_interval: float = 4.0,
                  colours: List[Tuple[int, int, int]] | None = None) -> None:
         # Connect to the remote pigpiod
-        self.pi = pigpio.pi(host)
+        port = pigpio.DEFAULT_PORT
+        self.pi = pigpio.pi(host, port)
+        if not self.pi.connected:
+            raise RuntimeError(
+                f"Failed to connect to pigpio daemon on {host}:{port}"
+            )
 
         # Configure the single data pin
         self.data_pin = DATA_PIN


### PR DESCRIPTION
## Summary
- verify pigpiod connection in Eyes class
- raise descriptive error with target host and port on failure

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'mini_bdx_runtime')*
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools)*

------
https://chatgpt.com/codex/tasks/task_e_689af29d2bf083299a9bb766861e8e61