### PR TITLE
Light LEDs with initial colour in Eyes init

### DIFF
--- a/mini_bdx_runtime/mini_bdx_runtime/eyes.py
+++ b/mini_bdx_runtime/mini_bdx_runtime/eyes.py
@@ -72,6 +72,10 @@ class Eyes:
         # Threading setup for blinking logic
         self._wave_lock = Lock()
         self._stop_event = Event()
+
+        # Light up the LEDs immediately with the initial colour
+        self.set_color(self.current_color)
+
         self._thread = Thread(target=self.run, daemon=True)
         self._thread.start()
 


### PR DESCRIPTION
## Summary
- Initialize eye LEDs with current colour immediately upon creation

## Testing
- `pytest` *(fails: ModuleNotFoundError for mini_bdx_runtime, picamzero, openai; pip install attempts blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_689af3b686a083298bfa74402d29a435