### PR TITLE
Clear pigpio waveform buffer before adding pulses

### DIFF
--- a/mini_bdx_runtime/mini_bdx_runtime/eyes.py
+++ b/mini_bdx_runtime/mini_bdx_runtime/eyes.py
@@ -132,6 +132,7 @@ class Eyes:
         """Send the given colour to both LEDs immediately."""
         with self._wave_lock:
             pulses = self._build_wave(colour)
+            self.pi.wave_clear()
             self.pi.wave_add_generic(pulses)
             wid = self.pi.wave_create()
             if wid < 0:


### PR DESCRIPTION
## Summary
- Ensure eye LED updates start from a clean pigpio waveform buffer by clearing existing data before adding new pulses

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'mini_bdx_runtime', 'picamzero', 'openai')*
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools; 403 connecting to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_689af4a980f483298b7d467477eb1c0b