### PR TITLE
Gracefully handle pigpio connection setup for eye LEDs

### DIFF
--- a/mini_bdx_runtime/mini_bdx_runtime/eyes.py
+++ b/mini_bdx_runtime/mini_bdx_runtime/eyes.py
@@ -46,8 +46,9 @@ class Eyes:
                  min_interval: float = 1.0,
                  max_interval: float = 4.0,
                  colours: List[Tuple[int, int, int]] | None = None) -> None:
-        # Connect to the remote pigpiod
-        port = pigpio.DEFAULT_PORT
+        # Connect to the remote pigpiod. pigpio<1.79 does not expose
+        # ``DEFAULT_PORT`` so fall back to the conventional 8888 port.
+        port = getattr(pigpio, "DEFAULT_PORT", 8888)
         self.pi = pigpio.pi(host, port)
         if not self.pi.connected:
             raise RuntimeError(

--- a/scripts/eyes_test.py
+++ b/scripts/eyes_test.py
@@ -12,7 +12,13 @@ def main() -> None:
                         help="Delay between colour changes in seconds")
     args = parser.parse_args()
 
-    eyes = Eyes(host=args.host, blink_duration=0.0, min_interval=1.0, max_interval=1.0)
+    try:
+        eyes = Eyes(host=args.host, blink_duration=0.0,
+                    min_interval=1.0, max_interval=1.0)
+    except RuntimeError as exc:
+        print(f"Eyes initialisation failed: {exc}")
+        return
+
     try:
         while True:
             eyes.cycle_color()


### PR DESCRIPTION
## Summary
- Use a safe fallback port when pigpio's `DEFAULT_PORT` is missing
- Exit `eyes_test.py` cleanly when pigpio connection fails

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'mini_bdx_runtime')*


------
https://chatgpt.com/codex/tasks/task_e_6899bc901398832988fab6feb32b013b